### PR TITLE
fix 101soundboards

### DIFF
--- a/101soundboards.py
+++ b/101soundboards.py
@@ -45,8 +45,10 @@ def find_sounds(url):
     check_if_none(target, 'info script')
 
     target = str(target)
-
-    sound_list = json.loads(target[target.find('board_data_preload') + 21:-11])
+    trimmedTarget = str(target[target.find('board_data_inline') + 20:target.find('}]};') + 3])
+    #print(trimmedTarget)
+    
+    sound_list = json.loads(trimmedTarget)
     #TODO: extract properties at this point
     """
         "id": 27782,
@@ -109,7 +111,8 @@ def find_sounds(url):
         res.append({
             'id': i['id'],
             'title': i['sound_transcript'],
-            'url': i['sound_file_url']
+            'url': i['sound_file_url'],
+            'dumbass_iphone_prefix_duration': i['sound_file_pitch']
             })
 
     return res
@@ -129,7 +132,8 @@ def handle_sound(sound, output_directory):
     filepath = output_directory + \
                 os.path.sep + \
                 sound['title'] + '-' + str(sound['id']) + '.mp3'
-    download_sound(sound['url'], filepath)
+    download_sound(sound['url'], filepath + '_' + str(sound['dumbass_iphone_prefix_duration']))
+    print('dumbass prefix duration is: ' + str(float(sound['dumbass_iphone_prefix_duration']) / 10))
 
 
 def worker(output_directory):


### PR DESCRIPTION
they changed the <script> a little bit... 

But they added these dumbass iphone sounds to the beginning of every .mp3 file.

The way I dealt with that was to name them according to how long the prefix is and then post-process them with ffmpeg like so

`for f in *.mp3_2; do ffmpeg -f mp3 -i "${f}" -ss 0.2 -vcodec copy -acodec copy -y "${f%%.*}.mp3"; done`
`for f in *.mp3_4; do ffmpeg -f mp3 -i "${f}" -ss 0.4 -vcodec copy -acodec copy -y "${f%%.*}.mp3"; done`
`for f in *.mp3_6; do ffmpeg -f mp3 -i "${f}" -ss 0.6 -vcodec copy -acodec copy -y "${f%%.*}.mp3"; done`
...
then move them all to a new folder `mv *.mp3 ./processed/`

you could probably automate that part, but I got what I wanted out of it
